### PR TITLE
prober: check response http status code

### DIFF
--- a/prober.go
+++ b/prober.go
@@ -3,6 +3,7 @@ package probing
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -60,6 +61,10 @@ func (p *prober) AddHTTP(id string, probingInterval time.Duration, endpoints []s
 					panic(err)
 				}
 				resp, err := p.tr.RoundTrip(req)
+				if err == nil && resp.StatusCode != http.StatusOK {
+					err = fmt.Errorf("got unexpected HTTP status code %s from %s", resp.Status, endpoints[pinned])
+					resp.Body.Close()
+				}
 				if err != nil {
 					s.recordFailure(err)
 					pinned = (pinned + 1) % len(endpoints)


### PR DESCRIPTION
I got my peer and client URLs mixed up in my cluster config, and I was seeing:

```
  W | rafthttp: health check for peer XXXX could not connect: json: cannot unmarshal number into Go value of type probing.Health
```

turns out $endpoint/raft/probing was returning 404. By checking the response status code, we can improve that to:

```
  W | rafthttp: health check for peer XXXX could not connect: got unexpected HTTP status code 404 Not Found from http://$endpoint/raft/probing
```